### PR TITLE
Add getDelegatedAccessToken to the Fixie client.

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "license": "MIT",
   "repository": "fixie-ai/fixie-sdk",
   "bugs": "https://github.com/fixie-ai/fixie-sdk/issues",

--- a/packages/fixie/src/client.ts
+++ b/packages/fixie/src/client.ts
@@ -643,6 +643,21 @@ export class FixieClient {
   }
 
   /**
+   * Create a new short-lived token that can be used as an API key to permit interactions with the
+   * given agent. You must own the agent.
+   *
+   * This is useful for example in the voice context where your client will connect directly to Fixie
+   * servers to stream audio. Your client can supply one of these delegated tokens created by your
+   * server to avoid leaking your API key to your client.
+   *
+   * @param options.agentId The ID of the agent to create a delegated token for.
+   */
+  async getDelegatedAccessToken({ agentId }: { agentId: string }): Promise<String> {
+    const response = (await this.requestJson(`/api/v1/agents/${agentId}/delegate-access`, {})) as { token: string };
+    return response?.token;
+  }
+
+  /**
    * Start a new conversation with an agent, optionally sending the initial message. (If you don't send the initial
    * message, the agent may.)
    *

--- a/packages/fixie/src/main.ts
+++ b/packages/fixie/src/main.ts
@@ -637,6 +637,17 @@ agent
     })
   );
 
+agent
+  .command('delegateAccess <agentId>')
+  .description('Create a new short-lived API key that allows interactions with the given agent.')
+  .action(
+    catchErrors(async (agentId: string) => {
+      const client = await AuthenticateOrLogIn({ apiUrl: program.opts().url });
+      const result = await client.getDelegatedAccessToken({ agentId });
+      showResult(result, program.opts().raw);
+    })
+  );
+
 registerDeployCommand(agent);
 registerServeCommand(agent);
 


### PR DESCRIPTION
```
$ yarn workspace fixie build-start agent delegateAccess 95346dd0-6a3c-477b-81dc-75166ad595af
❓ Ignoring invalid key fixie_api_key in /home/mike/.config/fixie/config.yaml
❓ Ignoring invalid key environment_auth_tokens in /home/mike/.config/fixie/config.yaml
"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmaXhpZS5haS9wcm9kIiwiYXVkIjoiaHR0cHM6Ly9maXhpZS5haSIsInRva2VuX3R5cGUiOiJkZWxlZ2F0ZWQiLCJyZWYiOiI0MyIsImFpZCI6Ijk1MzQ2ZGQwLTZhM2MtNDc3Yi04MWRjLTc1MTY2YWQ1OTVhZiIsImV4cCI6MTcwMTg5NjY4Nn0.Nl2L_jKpzBQNn1ZhBJXfFqLhtRvfJhtc5XYJS-WuYwQ"
```