### PR TITLE
Some changes to logging and initialization logic.

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-nodeLinker: pnp
+nodeLinker: node-modules
 
 packageExtensions:
   "@jest/core@*":

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "6.3.0",
+  "version": "6.3.0-rc1",
   "license": "MIT",
   "repository": "fixie-ai/fixie-sdk",
   "bugs": "https://github.com/fixie-ai/fixie-sdk/issues",

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "license": "MIT",
   "repository": "fixie-ai/fixie-sdk",
   "bugs": "https://github.com/fixie-ai/fixie-sdk/issues",


### PR DESCRIPTION
These changes are meant to address a couple of startup issues:

* There is a separate 'startAudio()' step that can be optionally called before 'start()' to get mic permissions before the peer starts speaking.
* Added a 'audioContext.resume()' in '.startAudio()' to fix issues where the AudioContext was initialized outside of a click handler and needed to be resumed.
* Added a bit of extra logging to help with debugging.
* There are some minor style cleanups here mostly to make lint happy.