### PR TITLE
Improved error handling in the voice client.

### DIFF
--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "6.3.2-rc1",
+  "version": "6.3.2",
   "license": "MIT",
   "repository": "fixie-ai/fixie-sdk",
   "bugs": "https://github.com/fixie-ai/fixie-sdk/issues",

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "6.3.2",
+  "version": "6.3.2-rc1",
   "license": "MIT",
   "repository": "fixie-ai/fixie-sdk",
   "bugs": "https://github.com/fixie-ai/fixie-sdk/issues",

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "6.3.0-rc1",
+  "version": "6.3.2",
   "license": "MIT",
   "repository": "fixie-ai/fixie-sdk",
   "bugs": "https://github.com/fixie-ai/fixie-sdk/issues",

--- a/packages/fixie/src/voice.ts
+++ b/packages/fixie/src/voice.ts
@@ -89,9 +89,6 @@ export class VoiceSession {
   /** Called when an error occurs. */
   onError?: (error: VoiceSessionError) => void;
 
-  /** Called when audio starts. */
-  onAudioStart?: () => void;
-
   constructor(
     private readonly agentId: AgentId,
     public conversationId?: ConversationId,
@@ -148,7 +145,6 @@ export class VoiceSession {
       this.sendData(obj);
     }, 5000);
     this.audioStarted = true;
-    this.onAudioStart?.();
   }
 
   /** Start this VoiceSession. This will call startAudio if it has not been called yet.*/

--- a/packages/fixie/src/voice.ts
+++ b/packages/fixie/src/voice.ts
@@ -89,11 +89,7 @@ export class VoiceSession {
   /** Called when an error occurs. */
   onError?: (error: VoiceSessionError) => void;
 
-  constructor(
-    private readonly agentId: AgentId,
-    public conversationId?: ConversationId,
-    private readonly params?: VoiceSessionInit
-  ) {
+  constructor(readonly agentId: AgentId, public conversationId?: ConversationId, readonly params?: VoiceSessionInit) {
     console.log('[voiceSession] creating VoiceSession');
   }
 

--- a/packages/fixie/src/voice.ts
+++ b/packages/fixie/src/voice.ts
@@ -163,7 +163,6 @@ export class VoiceSession {
     }
     this.started = true;
     this.maybePublishLocalAudio();
-    this.changeState(VoiceSessionState.IDLE);
   }
 
   /** Stop this VoiceSession. */
@@ -210,6 +209,7 @@ export class VoiceSession {
       console.log('[voiceSession] publishing local audio track');
       const opts = { name: 'audio', simulcast: false, source: Track.Source.Microphone };
       this.room.localParticipant.publishTrack(this.localAudioTrack, opts);
+      this.changeState(VoiceSessionState.IDLE);
     } else {
       console.log(
         `[voiceSession] not publishing local audio track - room state is ${this.room?.state}, local audio is ${

--- a/packages/fixie/src/voice.ts
+++ b/packages/fixie/src/voice.ts
@@ -94,8 +94,8 @@ export class VoiceSession {
 
   constructor(
     private readonly agentId: AgentId,
-    private readonly conversationId?: ConversationId,
-    private readonly params?: VoiceSessionInit
+    private readonly params?: VoiceSessionInit,
+    public conversationId?: ConversationId,
   ) {
     console.log('[voiceSession] creating VoiceSession');
   }
@@ -214,7 +214,7 @@ export class VoiceSession {
       console.log(
         `[voiceSession] not publishing local audio track - room state is ${this.room?.state}, local audio is ${
           this.localAudioTrack != null
-        }`
+        }`,
       );
     }
   }
@@ -258,7 +258,7 @@ export class VoiceSession {
         this.maybePublishLocalAudio();
         this.room.on(RoomEvent.TrackSubscribed, (track: RemoteTrack) => this.handleTrackSubscribed(track));
         this.room.on(RoomEvent.DataReceived, (payload: Uint8Array, participant: any) =>
-          this.handleDataReceived(payload, participant)
+          this.handleDataReceived(payload, participant),
         );
         break;
       default:
@@ -318,6 +318,8 @@ export class VoiceSession {
       this.handleOutputChange(msg.text, msg.final);
     } else if (msg.type == 'latency') {
       this.handleLatency(msg.kind, msg.value);
+    } else if (msg.type == 'conversation_created') {
+      this.conversationId = msg.conversationId;
     }
   }
 

--- a/packages/fixie/src/voice.ts
+++ b/packages/fixie/src/voice.ts
@@ -118,7 +118,6 @@ export class VoiceSession {
   /** Warm up the VoiceSession by making network connections. This is called automatically when the VoiceSession object is created. */
   warmup(): void {
     console.log('[voiceSession] warming up');
-    this.changeState(VoiceSessionState.CONNECTING);
     this.audioStarted = false;
     this.started = false;
     try {
@@ -127,6 +126,7 @@ export class VoiceSession {
       this.socket.onopen = () => this.handleSocketOpen();
       this.socket.onmessage = (event) => this.handleSocketMessage(event);
       this.socket.onclose = (event) => this.handleSocketClose(event);
+      this.changeState(VoiceSessionState.CONNECTING);
     } catch (e) {
       const err = e as Error;
       console.error('[voiceSession] failed to create socket', e);

--- a/packages/fixie/src/voice.ts
+++ b/packages/fixie/src/voice.ts
@@ -94,8 +94,8 @@ export class VoiceSession {
 
   constructor(
     private readonly agentId: AgentId,
-    private readonly params?: VoiceSessionInit,
     public conversationId?: ConversationId,
+    private readonly params?: VoiceSessionInit
   ) {
     console.log('[voiceSession] creating VoiceSession');
   }
@@ -214,7 +214,7 @@ export class VoiceSession {
       console.log(
         `[voiceSession] not publishing local audio track - room state is ${this.room?.state}, local audio is ${
           this.localAudioTrack != null
-        }`,
+        }`
       );
     }
   }
@@ -258,7 +258,7 @@ export class VoiceSession {
         this.maybePublishLocalAudio();
         this.room.on(RoomEvent.TrackSubscribed, (track: RemoteTrack) => this.handleTrackSubscribed(track));
         this.room.on(RoomEvent.DataReceived, (payload: Uint8Array, participant: any) =>
-          this.handleDataReceived(payload, participant),
+          this.handleDataReceived(payload, participant)
         );
         break;
       default:


### PR DESCRIPTION
This PR makes a few minor changes to improve error handling and debugging.

- We explicitly track the initializing state of the VoiceSession as it goes from created -> connecting -> connected -> audio enabled -> started. This is going to make it easier for applications to observe the state of the session and take appropriate action when errors or timeouts occur.
- The onError handler carries a VoiceSessionError object with information about the error. This is a simple message for now, but can be expanded later.
- Added a few additional places where .onError is called.

The more substantive (perhaps) change is that .warmup is no longer called in the ctor or when the socket closes. I would much rather this be done explicitly by application code, rather than the VoiceSession trying to be too clever. Constructors are not a good place to be doing actions like opening socket connections, anyway, because it's much harder to deal with errors that happen during the ctor. By having .warmup() be called explicitly, we can create the VoiceSession, set up the error handling logic, call .warmup, and deal gracefully with connection errors that might occur.

These changes allow us to have more graceful error handling in the Santa app.