### PR TITLE
Report worker round trip times as another form of latency instead of just logging to the console

### DIFF
--- a/packages/fixie-web/package.json
+++ b/packages/fixie-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fixie-web",
   "description": "Browser-based SDK for the Fixie platform.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/fixie-web/src/voice.ts
+++ b/packages/fixie-web/src/voice.ts
@@ -298,7 +298,7 @@ export class VoiceSession {
     const msg = JSON.parse(this.textDecoder.decode(payload));
     if (msg.type === 'pong') {
       const elapsed_ms = performance.now() - msg.timestamp;
-      console.debug(`[voiceSession] worker RTT: ${elapsed_ms.toFixed(0)} ms`);
+      this.handleLatency('workerRtt', elapsed_ms);
     } else if (msg.type === 'state') {
       const newState = msg.state;
       if (newState === VoiceSessionState.SPEAKING && this.outAnalyzer === undefined) {


### PR DESCRIPTION
Working on https://github.com/fixie-ai/fixie/issues/2378