### PR TITLE
Fix error when calling deleteRevision.

### DIFF
--- a/packages/fixie-common/CHANGELOG.md
+++ b/packages/fixie-common/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @fixieai/fixie-common
 
+## 1.0.10
+
+### Patch Changes
+
+- Fix issue with 204 return.
+
+## 1.0.9
+
+### Patch Changes
+
+- Fix deleteRevision.
+
 ## 1.0.8
 
 ### Patch Changes

--- a/packages/fixie-common/CHANGELOG.md
+++ b/packages/fixie-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fixieai/fixie-common
 
+## 1.0.7
+
+### Patch Changes
+
+- Fix createRevision and agent deployment.
+
 ## 1.0.6
 
 ### Patch Changes

--- a/packages/fixie-common/CHANGELOG.md
+++ b/packages/fixie-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fixieai/fixie-common
 
+## 1.0.8
+
+### Patch Changes
+
+- Fix agent deployment.
+
 ## 1.0.7
 
 ### Patch Changes

--- a/packages/fixie-common/package.json
+++ b/packages/fixie-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fixieai/fixie-common",
   "description": "Node and browser common code for the Fixie platform SDK.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/fixie-common/package.json
+++ b/packages/fixie-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fixieai/fixie-common",
   "description": "Node and browser common code for the Fixie platform SDK.",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/fixie-common/package.json
+++ b/packages/fixie-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fixieai/fixie-common",
   "description": "Node and browser common code for the Fixie platform SDK.",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/fixie-common/src/agent.ts
+++ b/packages/fixie-common/src/agent.ts
@@ -277,7 +277,6 @@ export class FixieAgentBase {
     if (externalUrl !== undefined) {
       externalDeployment = {
         url: externalUrl,
-        runtimeParametersSchema,
       };
     }
     const result = (await this.client.requestJson(`/api/v1/agents/${this.metadata.agentId}/revisions`, {
@@ -285,6 +284,9 @@ export class FixieAgentBase {
         isCurrent,
         deployment: {
           external: externalDeployment,
+        },
+        runtime: {
+          parametersSchema: runtimeParametersSchema,
         },
         // The API expects this field to be pre-JSON-encoded.
         defaultRuntimeParameters: JSON.stringify(defaultRuntimeParameters),

--- a/packages/fixie-common/src/agent.ts
+++ b/packages/fixie-common/src/agent.ts
@@ -84,6 +84,7 @@ export class FixieAgentBase {
     return (result as any as { agent: Agent }).agent;
   }
 
+  /** Create a new Agent. */
   public static async CreateAgent({
     client,
     handle,
@@ -91,7 +92,7 @@ export class FixieAgentBase {
     displayName,
     description,
     moreInfoUrl,
-    published,
+    published = true,
   }: {
     client: FixieClientBase;
     handle: string;

--- a/packages/fixie-common/src/agent.ts
+++ b/packages/fixie-common/src/agent.ts
@@ -301,11 +301,7 @@ export class FixieAgentBase {
     this.update({ currentRevisionId: revisionId });
   }
 
-  public deleteRevision(revisionId: string): Promise<void> {
-    return this.client.requestJson(
-      `/api/v1/agents/${this.metadata.agentId}/revisions/${revisionId}`,
-      undefined,
-      'DELETE'
-    );
+  public deleteRevision(revisionId: string) {
+    this.client.requestJson(`/api/v1/agents/${this.metadata.agentId}/revisions/${revisionId}`, undefined, 'DELETE');
   }
 }

--- a/packages/fixie-common/src/client.ts
+++ b/packages/fixie-common/src/client.ts
@@ -100,6 +100,9 @@ export class FixieClientBase {
 
   async requestJson<T = Jsonifiable>(path: string, bodyData?: unknown, method?: string): Promise<T> {
     const response = await this.request(path, bodyData, method);
+    if (response.status === 204) {
+      return {} as T;
+    }
     return response.json();
   }
 

--- a/packages/fixie-common/tests/agent.test.ts
+++ b/packages/fixie-common/tests/agent.test.ts
@@ -329,11 +329,15 @@ describe('FixieAgentBase AgentRevision tests', () => {
         revisionId: 'new-revision-id',
         created: '2021-08-31T18:00:00.000Z',
         isCurrent: true,
+        runtime: {
+          parametersSchema: '{"type":"object"}',
+        },
       },
     });
     const revision = await agent.createRevision({
       defaultRuntimeParameters: { foo: 'bar' },
       externalUrl: 'https://fake.url',
+      runtimeParametersSchema: '{"type":"object"}',
     });
     expect(mock.mock.calls[0][0].toString()).toStrictEqual(
       'https://fake.api.fixie.ai/api/v1/agents/fake-agent-id/revisions'
@@ -347,6 +351,9 @@ describe('FixieAgentBase AgentRevision tests', () => {
             external: {
               url: 'https://fake.url',
             },
+          },
+          runtime: {
+            parametersSchema: '{"type":"object"}',
           },
           defaultRuntimeParameters: '{"foo":"bar"}',
         },

--- a/packages/fixie/CHANGELOG.md
+++ b/packages/fixie/CHANGELOG.md
@@ -1,5 +1,13 @@
 # fixie
 
+## 7.0.7
+
+### Patch Changes
+
+- Fix createRevision and agent deployment.
+- Updated dependencies
+  - @fixieai/fixie-common@1.0.7
+
 ## 7.0.6
 
 ### Patch Changes

--- a/packages/fixie/CHANGELOG.md
+++ b/packages/fixie/CHANGELOG.md
@@ -1,5 +1,21 @@
 # fixie
 
+## 7.0.10
+
+### Patch Changes
+
+- Fix issue with 204 return.
+- Updated dependencies
+  - @fixieai/fixie-common@1.0.10
+
+## 7.0.9
+
+### Patch Changes
+
+- Fix deleteRevision.
+- Updated dependencies
+  - @fixieai/fixie-common@1.0.9
+
 ## 7.0.8
 
 ### Patch Changes

--- a/packages/fixie/CHANGELOG.md
+++ b/packages/fixie/CHANGELOG.md
@@ -1,5 +1,13 @@
 # fixie
 
+## 7.0.8
+
+### Patch Changes
+
+- Fix agent deployment.
+- Updated dependencies
+  - @fixieai/fixie-common@1.0.8
+
 ## 7.0.7
 
 ### Patch Changes

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "license": "MIT",
   "repository": "fixie-ai/fixie-sdk",
   "bugs": "https://github.com/fixie-ai/fixie-sdk/issues",
@@ -21,7 +21,7 @@
   "bin": "dist/src/cli.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@fixieai/fixie-common": "^1.0.6",
+    "@fixieai/fixie-common": "^1.0.7",
     "axios": "^1.6.3",
     "commander": "^11.0.0",
     "execa": "^8.0.1",

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "7.0.8",
+  "version": "7.0.10",
   "license": "MIT",
   "repository": "fixie-ai/fixie-sdk",
   "bugs": "https://github.com/fixie-ai/fixie-sdk/issues",
@@ -21,7 +21,7 @@
   "bin": "dist/src/cli.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@fixieai/fixie-common": "^1.0.8",
+    "@fixieai/fixie-common": "^1.0.10",
     "axios": "^1.6.3",
     "commander": "^11.0.0",
     "execa": "^8.0.1",

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "license": "MIT",
   "repository": "fixie-ai/fixie-sdk",
   "bugs": "https://github.com/fixie-ai/fixie-sdk/issues",
@@ -21,7 +21,7 @@
   "bin": "dist/src/cli.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@fixieai/fixie-common": "^1.0.7",
+    "@fixieai/fixie-common": "^1.0.8",
     "axios": "^1.6.3",
     "commander": "^11.0.0",
     "execa": "^8.0.1",

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -188,6 +188,7 @@ export class FixieAgent extends FixieAgentBase {
         displayName: config.name,
         description: config.description,
         moreInfoUrl: config.moreInfoUrl,
+        published: true,
       })) as FixieAgent;
     }
     return agent as FixieAgent;

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -232,11 +232,17 @@ export class FixieAgent extends FixieAgentBase {
   }
 
   /** Deploy an agent from the given directory. */
-  public static async DeployAgent(
-    client: FixieClient,
-    agentPath: string,
-    environmentVariables: Record<string, string> = {}
-  ): Promise<AgentRevision> {
+  public static async DeployAgent({
+    client,
+    agentPath,
+    environmentVariables = {},
+    teamId,
+  }: {
+    client: FixieClient;
+    agentPath: string;
+    environmentVariables: Record<string, string>;
+    teamId?: string;
+  }): Promise<AgentRevision> {
     const config = await FixieAgent.LoadConfig(agentPath);
     term('🦊 Deploying agent ').green(config.handle)('...\n');
 
@@ -260,7 +266,7 @@ export class FixieAgent extends FixieAgentBase {
       );
     }
 
-    const agent = (await FixieAgent.ensureAgent({ client, config })) as FixieAgent;
+    const agent = (await FixieAgent.ensureAgent({ client, config, teamId })) as FixieAgent;
 
     const runtimeParametersSchema = FixieAgent.inferRuntimeParametersSchema(agentPath);
     const tarball = FixieAgent.getCodePackage(agentPath);
@@ -282,6 +288,7 @@ export class FixieAgent extends FixieAgentBase {
     port,
     environmentVariables,
     debug,
+    teamId,
   }: {
     client: FixieClient;
     agentPath: string;
@@ -289,6 +296,7 @@ export class FixieAgent extends FixieAgentBase {
     port: number;
     environmentVariables: Record<string, string>;
     debug?: boolean;
+    teamId?: string;
   }) {
     const config = await FixieAgent.LoadConfig(agentPath);
     term('🦊 Serving agent ').green(config.handle)('...\n');
@@ -375,7 +383,7 @@ export class FixieAgent extends FixieAgentBase {
       })();
     }
 
-    const agent = await this.ensureAgent({ client, config });
+    const agent = await this.ensureAgent({ client, config, teamId });
     const originalRevision = await agent.getCurrentRevision();
     if (originalRevision) {
       term('🥡 Replacing current agent revision ').green(originalRevision.revisionId)('\n');

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -326,6 +326,9 @@ export class FixieAgent extends FixieAgentBase {
 
     // Infer the runtime parameters schema. We'll create a generator that yields whenever the schema changes.
     let runtimeParametersSchema = FixieAgent.inferRuntimeParametersSchema(agentPath);
+
+    console.log(`🌱 Runtime parameters schema: ${JSON.stringify(runtimeParametersSchema)}`);
+
     const { iterator: schemaGenerator, push: pushToSchemaGenerator } =
       this.createAsyncIterable<TJS.Definition | null>();
     pushToSchemaGenerator(runtimeParametersSchema);

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -170,11 +170,13 @@ export class FixieAgent extends FixieAgentBase {
     const result = (await this.client.requestJson(`/api/v1/agents/${this.metadata.agentId}/revisions`, {
       revision: {
         isCurrent,
+        runtime: {
+          parametersSchema: runtimeParametersSchema,
+        },
         deployment: {
           managed: {
             codePackage,
             environmentVariables: envVars,
-            runtimeParametersSchema,
           },
         },
         defaultRuntimeParameters,

--- a/packages/fixie/tests/agent.test.ts
+++ b/packages/fixie/tests/agent.test.ts
@@ -57,31 +57,7 @@ describe('FixieAgent AgentRevision tests', () => {
     jest.clearAllMocks();
   });
 
-  it('createRevision requires either externalUrl, tarball, or defaultRuntimeParameters', async () => {
-    expect(async () => await agent.createRevision({})).rejects.toThrow();
-  });
-
-  it('createRevision with externalUrl cannot have tarball specified', async () => {
-    expect(
-      async () => await agent.createRevision({ externalUrl: 'https://foo.com', tarball: 'abc.tar.gz' })
-    ).rejects.toThrow();
-  });
-
-  it('createRevision with externalUrl cannot have environmentVariables specified', async () => {
-    expect(
-      async () => await agent.createRevision({ externalUrl: 'https://foo.com', environmentVariables: { foo: 'bar' } })
-    ).rejects.toThrow();
-  });
-
-  it('createRevision with environmentVariables must have tarball specified', async () => {
-    expect(async () => await agent.createRevision({ environmentVariables: { foo: 'bar' } })).rejects.toThrow();
-  });
-
-  it('createRevision with runtimeParametersSchema requires externalUrl', async () => {
-    expect(async () => await agent.createRevision({ runtimeParametersSchema: '{}' })).rejects.toThrow();
-  });
-
-  it('createRevision accepts tarball', async () => {
+  it('createManagedRevision accepts tarball', async () => {
     const tarball = 'tests/fixtures/test-tarball.tar.gz';
     const tarballData = fs.readFileSync(fs.realpathSync(tarball));
     const codePackage = tarballData.toString('base64');
@@ -94,7 +70,7 @@ describe('FixieAgent AgentRevision tests', () => {
         isCurrent: true,
       },
     });
-    const revision = await agent.createRevision({
+    const revision = await agent.createManagedRevision({
       defaultRuntimeParameters: { foo: 'bar' },
       tarball,
       environmentVariables: { TEST_ENV_VAR: 'test env var value' },
@@ -114,7 +90,7 @@ describe('FixieAgent AgentRevision tests', () => {
           deployment: {
             managed: {
               codePackage,
-              environmentVariables: [{ name: 'TEST_ENV_VAR', value: 'test env var value' }],
+              environmentVariables: { TEST_ENV_VAR: 'test env var value' },
             },
           },
           defaultRuntimeParameters: { foo: 'bar' },
@@ -127,23 +103,15 @@ describe('FixieAgent AgentRevision tests', () => {
     expect(revision?.isCurrent).toBe(true);
   });
 
-  it('createRevision with missing tarball throws', async () => {
+  it('createManagedRevision with missing tarball throws', async () => {
     expect(
       async () =>
-        await agent.createRevision({
+        await agent.createManagedRevision({
           defaultRuntimeParameters: { foo: 'bar' },
           tarball: 'bogus-tarball-filename',
           environmentVariables: { TEST_ENV_VAR: 'test env var value' },
           runtimeParametersSchema: '{"type": "object"}',
         })
     ).rejects.toThrow();
-  });
-
-  it('createRevision requires either externalUrl or defaultRuntimeParameters', async () => {
-    expect(async () => await agent.createRevision({})).rejects.toThrow();
-  });
-
-  it('createRevision with runtimeParametersSchema requires externalUrl', async () => {
-    expect(async () => await agent.createRevision({ runtimeParametersSchema: '{}' })).rejects.toThrow();
   });
 });

--- a/packages/fixie/tests/agent.test.ts
+++ b/packages/fixie/tests/agent.test.ts
@@ -98,7 +98,7 @@ describe('FixieAgent AgentRevision tests', () => {
       defaultRuntimeParameters: { foo: 'bar' },
       tarball,
       environmentVariables: { TEST_ENV_VAR: 'test env var value' },
-      runtimeParametersSchema: '{}',
+      runtimeParametersSchema: '{"type": "object"}',
     });
     expect(mock.mock.calls[0][0].toString()).toStrictEqual(
       'https://fake.api.fixie.ai/api/v1/agents/fake-agent-id/revisions'
@@ -108,11 +108,13 @@ describe('FixieAgent AgentRevision tests', () => {
       JSON.stringify({
         revision: {
           isCurrent: true,
+          runtime: {
+            parametersSchema: '{"type": "object"}',
+          },
           deployment: {
             managed: {
               codePackage,
               environmentVariables: [{ name: 'TEST_ENV_VAR', value: 'test env var value' }],
-              runtimeParametersSchema: '{}',
             },
           },
           defaultRuntimeParameters: { foo: 'bar' },
@@ -132,7 +134,7 @@ describe('FixieAgent AgentRevision tests', () => {
           defaultRuntimeParameters: { foo: 'bar' },
           tarball: 'bogus-tarball-filename',
           environmentVariables: { TEST_ENV_VAR: 'test env var value' },
-          runtimeParametersSchema: '{}',
+          runtimeParametersSchema: '{"type": "object"}',
         })
     ).rejects.toThrow();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,7 +731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fixieai/fixie-common@^1.0.6, @fixieai/fixie-common@workspace:packages/fixie-common":
+"@fixieai/fixie-common@^1.0.6, @fixieai/fixie-common@^1.0.7, @fixieai/fixie-common@workspace:packages/fixie-common":
   version: 0.0.0-use.local
   resolution: "@fixieai/fixie-common@workspace:packages/fixie-common"
   dependencies:
@@ -3684,7 +3684,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "fixie@workspace:packages/fixie"
   dependencies:
-    "@fixieai/fixie-common": ^1.0.6
+    "@fixieai/fixie-common": ^1.0.7
     "@tsconfig/node18": ^2.0.1
     "@types/extract-files": ^8.1.1
     "@types/jest": ^29.5.11

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,7 +731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fixieai/fixie-common@^1.0.6, @fixieai/fixie-common@^1.0.7, @fixieai/fixie-common@workspace:packages/fixie-common":
+"@fixieai/fixie-common@^1.0.6, @fixieai/fixie-common@^1.0.8, @fixieai/fixie-common@workspace:packages/fixie-common":
   version: 0.0.0-use.local
   resolution: "@fixieai/fixie-common@workspace:packages/fixie-common"
   dependencies:
@@ -3684,7 +3684,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "fixie@workspace:packages/fixie"
   dependencies:
-    "@fixieai/fixie-common": ^1.0.7
+    "@fixieai/fixie-common": ^1.0.8
     "@tsconfig/node18": ^2.0.1
     "@types/extract-files": ^8.1.1
     "@types/jest": ^29.5.11

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,7 +731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fixieai/fixie-common@^1.0.6, @fixieai/fixie-common@^1.0.8, @fixieai/fixie-common@workspace:packages/fixie-common":
+"@fixieai/fixie-common@^1.0.10, @fixieai/fixie-common@^1.0.6, @fixieai/fixie-common@workspace:packages/fixie-common":
   version: 0.0.0-use.local
   resolution: "@fixieai/fixie-common@workspace:packages/fixie-common"
   dependencies:
@@ -3684,7 +3684,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "fixie@workspace:packages/fixie"
   dependencies:
-    "@fixieai/fixie-common": ^1.0.8
+    "@fixieai/fixie-common": ^1.0.10
     "@tsconfig/node18": ^2.0.1
     "@types/extract-files": ^8.1.1
     "@types/jest": ^29.5.11


### PR DESCRIPTION
The code for requestJson was not dealing properly with empty response bodies from 204 responses, so an error was getting raised when calling deleteRevision that should not have been raised. This fixes that.
