### PR TITLE
Add support for specifying default parameters on CLI

### DIFF
--- a/packages/fixie-common/CHANGELOG.md
+++ b/packages/fixie-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fixieai/fixie-common
 
+## 1.0.12
+
+### Patch Changes
+
+- Added support for specifying default runtime parameters
+
 ## 1.0.11
 
 ### Patch Changes

--- a/packages/fixie-common/package.json
+++ b/packages/fixie-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fixieai/fixie-common",
   "description": "Node and browser common code for the Fixie platform SDK.",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/fixie-common/src/agent.ts
+++ b/packages/fixie-common/src/agent.ts
@@ -264,7 +264,7 @@ export class FixieAgentBase {
   }: {
     defaultRuntimeParameters?: Record<string, unknown>;
     externalUrl?: string;
-    runtimeParametersSchema?: string;
+    runtimeParametersSchema?: Record<string, unknown> | null;
     isCurrent?: boolean;
   }): Promise<AgentRevision> {
     if (externalUrl === undefined && defaultRuntimeParameters === undefined) {
@@ -287,10 +287,9 @@ export class FixieAgentBase {
           external: externalDeployment,
         },
         runtime: {
-          parametersSchema: runtimeParametersSchema,
+          parametersSchema: runtimeParametersSchema && JSON.stringify(runtimeParametersSchema),
         },
-        // The API expects this field to be pre-JSON-encoded.
-        defaultRuntimeParameters: JSON.stringify(defaultRuntimeParameters),
+        defaultRuntimeParameters: defaultRuntimeParameters && JSON.stringify(defaultRuntimeParameters),
       },
     })) as { revision: AgentRevision };
     return result.revision;

--- a/packages/fixie-common/src/agent.ts
+++ b/packages/fixie-common/src/agent.ts
@@ -264,7 +264,7 @@ export class FixieAgentBase {
   }: {
     defaultRuntimeParameters?: Record<string, unknown>;
     externalUrl?: string;
-    runtimeParametersSchema?: Record<string, unknown> | null;
+    runtimeParametersSchema?: Record<string, unknown>;
     isCurrent?: boolean;
   }): Promise<AgentRevision> {
     if (externalUrl === undefined && defaultRuntimeParameters === undefined) {
@@ -287,9 +287,9 @@ export class FixieAgentBase {
           external: externalDeployment,
         },
         runtime: {
-          parametersSchema: runtimeParametersSchema && JSON.stringify(runtimeParametersSchema),
+          parametersSchema: runtimeParametersSchema,
         },
-        defaultRuntimeParameters: defaultRuntimeParameters && JSON.stringify(defaultRuntimeParameters),
+        defaultRuntimeParameters,
       },
     })) as { revision: AgentRevision };
     return result.revision;

--- a/packages/fixie-common/tests/agent.test.ts
+++ b/packages/fixie-common/tests/agent.test.ts
@@ -337,7 +337,7 @@ describe('FixieAgentBase AgentRevision tests', () => {
     const revision = await agent.createRevision({
       defaultRuntimeParameters: { foo: 'bar' },
       externalUrl: 'https://fake.url',
-      runtimeParametersSchema: '{"type":"object"}',
+      runtimeParametersSchema: { type: 'object' },
     });
     expect(mock.mock.calls[0][0].toString()).toStrictEqual(
       'https://fake.api.fixie.ai/api/v1/agents/fake-agent-id/revisions'
@@ -370,6 +370,6 @@ describe('FixieAgentBase AgentRevision tests', () => {
   });
 
   it('createRevision with runtimeParametersSchema requires externalUrl', async () => {
-    expect(async () => await agent.createRevision({ runtimeParametersSchema: '{}' })).rejects.toThrow();
+    expect(async () => await agent.createRevision({ runtimeParametersSchema: {} })).rejects.toThrow();
   });
 });

--- a/packages/fixie-common/tests/agent.test.ts
+++ b/packages/fixie-common/tests/agent.test.ts
@@ -353,9 +353,9 @@ describe('FixieAgentBase AgentRevision tests', () => {
             },
           },
           runtime: {
-            parametersSchema: '{"type":"object"}',
+            parametersSchema: { type: 'object' },
           },
-          defaultRuntimeParameters: '{"foo":"bar"}',
+          defaultRuntimeParameters: { foo: 'bar' },
         },
       })
     );

--- a/packages/fixie-web/CHANGELOG.md
+++ b/packages/fixie-web/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Patch Changes
 
+- Added support for specifying default runtime parameters
+- Updated dependencies
+  - @fixieai/fixie-common@1.0.12
+
+## 1.0.10
+
+### Patch Changes
+
 - Automatically warm up voice session in start()
 
 ## 1.0.8

--- a/packages/fixie-web/package.json
+++ b/packages/fixie-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fixie-web",
   "description": "Browser-based SDK for the Fixie platform.",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "dependencies": {
-    "@fixieai/fixie-common": "^1.0.6",
+    "@fixieai/fixie-common": "^1.0.12",
     "base64-arraybuffer": "^1.0.2",
     "livekit-client": "^1.15.2",
     "type-fest": "^4.3.1"

--- a/packages/fixie/CHANGELOG.md
+++ b/packages/fixie/CHANGELOG.md
@@ -1,5 +1,13 @@
 # fixie
 
+## 7.0.12
+
+### Patch Changes
+
+- Added support for specifying default runtime parameters
+- Updated dependencies
+  - @fixieai/fixie-common@1.0.12
+
 ## 7.0.11
 
 ### Patch Changes

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "7.0.11",
+  "version": "7.0.12",
   "license": "MIT",
   "repository": "fixie-ai/fixie-sdk",
   "bugs": "https://github.com/fixie-ai/fixie-sdk/issues",
@@ -21,7 +21,7 @@
   "bin": "dist/src/cli.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@fixieai/fixie-common": "^1.0.11",
+    "@fixieai/fixie-common": "^1.0.12",
     "axios": "^1.6.3",
     "commander": "^11.0.0",
     "execa": "^8.0.1",

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -127,7 +127,7 @@ export class FixieAgent extends FixieAgentBase {
   }: {
     tarball: string;
     defaultRuntimeParameters?: Record<string, unknown>;
-    runtimeParametersSchema?: Record<string, unknown> | null;
+    runtimeParametersSchema?: Record<string, unknown>;
     isCurrent?: boolean;
     environmentVariables?: Record<string, string>;
   }): Promise<AgentRevision> {
@@ -138,7 +138,7 @@ export class FixieAgent extends FixieAgentBase {
       revision: {
         isCurrent,
         runtime: {
-          parametersSchema: runtimeParametersSchema && JSON.stringify(runtimeParametersSchema),
+          parametersSchema: runtimeParametersSchema,
         },
         deployment: {
           managed: {
@@ -146,7 +146,7 @@ export class FixieAgent extends FixieAgentBase {
             environmentVariables,
           },
         },
-        defaultRuntimeParameters: defaultRuntimeParameters && JSON.stringify(defaultRuntimeParameters),
+        defaultRuntimeParameters: defaultRuntimeParameters,
       },
     })) as { revision: AgentRevision };
     return result.revision;
@@ -271,7 +271,7 @@ export class FixieAgent extends FixieAgentBase {
     const revision = await agent.createManagedRevision({
       tarball,
       environmentVariables,
-      runtimeParametersSchema: runtimeParametersSchema as Record<string, unknown>,
+      runtimeParametersSchema: (runtimeParametersSchema ?? undefined) as Record<string, unknown> | undefined,
       defaultRuntimeParameters,
     });
     spinner.succeed(`Agent ${config.handle} is running at: ${agent.agentUrl(client.url)}`);
@@ -430,7 +430,7 @@ export class FixieAgent extends FixieAgentBase {
         }
         currentRevision = await agent.createRevision({
           externalUrl: currentUrl,
-          runtimeParametersSchema: runtimeParametersSchema as Record<string, unknown>,
+          runtimeParametersSchema: (runtimeParametersSchema ?? undefined) as Record<string, unknown>,
           defaultRuntimeParameters,
         });
         term('🥡 Created temporary agent revision ').green(currentRevision.revisionId)('\n');

--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -87,12 +87,7 @@ export class FixieAgent extends FixieAgentBase {
       `
     );
     const program = TJS.programFromConfig(tsconfigPath, [tempPath]);
-    const schema = TJS.generateSchema(program, 'RuntimeParameters', settings);
-    if (schema && schema.type !== 'object') {
-      throw new Error(`The first argument of your default export must be an object (not ${schema.type})`);
-    }
-
-    return schema;
+    return TJS.generateSchema(program, 'RuntimeParameters', settings);
   }
 
   /** Package the code in the given directory and return the path to the tarball. */
@@ -132,7 +127,7 @@ export class FixieAgent extends FixieAgentBase {
   }: {
     tarball: string;
     defaultRuntimeParameters?: Record<string, unknown>;
-    runtimeParametersSchema?: string;
+    runtimeParametersSchema?: Record<string, unknown> | null;
     isCurrent?: boolean;
     environmentVariables?: Record<string, string>;
   }): Promise<AgentRevision> {
@@ -143,7 +138,7 @@ export class FixieAgent extends FixieAgentBase {
       revision: {
         isCurrent,
         runtime: {
-          parametersSchema: runtimeParametersSchema,
+          parametersSchema: runtimeParametersSchema && JSON.stringify(runtimeParametersSchema),
         },
         deployment: {
           managed: {
@@ -151,7 +146,7 @@ export class FixieAgent extends FixieAgentBase {
             environmentVariables,
           },
         },
-        defaultRuntimeParameters,
+        defaultRuntimeParameters: defaultRuntimeParameters && JSON.stringify(defaultRuntimeParameters),
       },
     })) as { revision: AgentRevision };
     return result.revision;
@@ -236,11 +231,13 @@ export class FixieAgent extends FixieAgentBase {
     client,
     agentPath,
     environmentVariables = {},
+    defaultRuntimeParameters = {},
     teamId,
   }: {
     client: FixieClient;
     agentPath: string;
     environmentVariables: Record<string, string>;
+    defaultRuntimeParameters?: Record<string, unknown>;
     teamId?: string;
   }): Promise<AgentRevision> {
     const config = await FixieAgent.LoadConfig(agentPath);
@@ -274,7 +271,8 @@ export class FixieAgent extends FixieAgentBase {
     const revision = await agent.createManagedRevision({
       tarball,
       environmentVariables,
-      runtimeParametersSchema: JSON.stringify(runtimeParametersSchema),
+      runtimeParametersSchema: runtimeParametersSchema as Record<string, unknown>,
+      defaultRuntimeParameters,
     });
     spinner.succeed(`Agent ${config.handle} is running at: ${agent.agentUrl(client.url)}`);
     return revision;
@@ -287,6 +285,7 @@ export class FixieAgent extends FixieAgentBase {
     tunnel,
     port,
     environmentVariables,
+    defaultRuntimeParameters = {},
     debug,
     teamId,
   }: {
@@ -295,6 +294,7 @@ export class FixieAgent extends FixieAgentBase {
     tunnel?: boolean;
     port: number;
     environmentVariables: Record<string, string>;
+    defaultRuntimeParameters?: Record<string, unknown>;
     debug?: boolean;
     teamId?: string;
   }) {
@@ -430,7 +430,8 @@ export class FixieAgent extends FixieAgentBase {
         }
         currentRevision = await agent.createRevision({
           externalUrl: currentUrl,
-          runtimeParametersSchema: JSON.stringify(runtimeParametersSchema),
+          runtimeParametersSchema: runtimeParametersSchema as Record<string, unknown>,
+          defaultRuntimeParameters,
         });
         term('🥡 Created temporary agent revision ').green(currentRevision.revisionId)('\n');
         term('🥡 Agent ').green(config.handle)(' is running at: ').green(agent.agentUrl(client.url))('\n');

--- a/packages/fixie/tests/agent.test.ts
+++ b/packages/fixie/tests/agent.test.ts
@@ -85,7 +85,7 @@ describe('FixieAgent AgentRevision tests', () => {
         revision: {
           isCurrent: true,
           runtime: {
-            parametersSchema: '{"type":"object"}',
+            parametersSchema: { type: 'object' },
           },
           deployment: {
             managed: {
@@ -93,7 +93,7 @@ describe('FixieAgent AgentRevision tests', () => {
               environmentVariables: { TEST_ENV_VAR: 'test env var value' },
             },
           },
-          defaultRuntimeParameters: '{"foo":"bar"}',
+          defaultRuntimeParameters: { foo: 'bar' },
         },
       })
     );

--- a/packages/fixie/tests/agent.test.ts
+++ b/packages/fixie/tests/agent.test.ts
@@ -74,7 +74,7 @@ describe('FixieAgent AgentRevision tests', () => {
       defaultRuntimeParameters: { foo: 'bar' },
       tarball,
       environmentVariables: { TEST_ENV_VAR: 'test env var value' },
-      runtimeParametersSchema: '{"type": "object"}',
+      runtimeParametersSchema: { type: 'object' },
     });
     expect(mock.mock.calls[0][0].toString()).toStrictEqual(
       'https://fake.api.fixie.ai/api/v1/agents/fake-agent-id/revisions'
@@ -85,7 +85,7 @@ describe('FixieAgent AgentRevision tests', () => {
         revision: {
           isCurrent: true,
           runtime: {
-            parametersSchema: '{"type": "object"}',
+            parametersSchema: '{"type":"object"}',
           },
           deployment: {
             managed: {
@@ -93,7 +93,7 @@ describe('FixieAgent AgentRevision tests', () => {
               environmentVariables: { TEST_ENV_VAR: 'test env var value' },
             },
           },
-          defaultRuntimeParameters: { foo: 'bar' },
+          defaultRuntimeParameters: '{"foo":"bar"}',
         },
       })
     );
@@ -110,7 +110,7 @@ describe('FixieAgent AgentRevision tests', () => {
           defaultRuntimeParameters: { foo: 'bar' },
           tarball: 'bogus-tarball-filename',
           environmentVariables: { TEST_ENV_VAR: 'test env var value' },
-          runtimeParametersSchema: '{"type": "object"}',
+          runtimeParametersSchema: { type: 'object' },
         })
     ).rejects.toThrow();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,7 +731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fixieai/fixie-common@^1.0.11, @fixieai/fixie-common@^1.0.6, @fixieai/fixie-common@workspace:packages/fixie-common":
+"@fixieai/fixie-common@^1.0.12, @fixieai/fixie-common@workspace:packages/fixie-common":
   version: 0.0.0-use.local
   resolution: "@fixieai/fixie-common@workspace:packages/fixie-common"
   dependencies:
@@ -3654,7 +3654,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "fixie-web@workspace:packages/fixie-web"
   dependencies:
-    "@fixieai/fixie-common": ^1.0.6
+    "@fixieai/fixie-common": ^1.0.12
     "@tsconfig/node18": ^2.0.1
     "@types/react": ^18.2.22
     "@types/react-dom": ^18.2.7
@@ -3684,7 +3684,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "fixie@workspace:packages/fixie"
   dependencies:
-    "@fixieai/fixie-common": ^1.0.11
+    "@fixieai/fixie-common": ^1.0.12
     "@tsconfig/node18": ^2.0.1
     "@types/extract-files": ^8.1.1
     "@types/jest": ^29.5.11


### PR DESCRIPTION
This ports https://github.com/fixie-ai/ai-jsx/pull/504 over to this repo. This also changes the function signature of `createRevision` to take JSON objects and uses those objects for the underlying API calls.