### PR TITLE
Add missing teamId

### DIFF
--- a/packages/fixie/src/agent.ts
+++ b/packages/fixie/src/agent.ts
@@ -188,6 +188,7 @@ export class FixieAgent extends FixieAgentBase {
         displayName: config.name,
         description: config.description,
         moreInfoUrl: config.moreInfoUrl,
+        teamId,
         published: true,
       })) as FixieAgent;
     }


### PR DESCRIPTION
`ensureAgent` ignored `teamId` when creating an agent.