### PR TITLE
Fix issue with listing agents.

### DIFF
--- a/packages/fixie-common/CHANGELOG.md
+++ b/packages/fixie-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fixieai/fixie-common
 
+## 1.0.14
+
+### Patch Changes
+
+- Fix issue with agent listing.
+
 ## 1.0.13
 
 ### Patch Changes

--- a/packages/fixie-common/package.json
+++ b/packages/fixie-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fixieai/fixie-common",
   "description": "Node and browser common code for the Fixie platform SDK.",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/fixie-common/src/agent.ts
+++ b/packages/fixie-common/src/agent.ts
@@ -62,6 +62,9 @@ export class FixieAgentBase {
     let requestOffset = offset;
     while (true) {
       const requestLimit = Math.min(limit - agentList.length, 100);
+      if (requestLimit <= 0) {
+        break;
+      }
       const result = (await client.requestJson(
         `/api/v1/agents?offset=${requestOffset}&limit=${requestLimit}${
           teamId !== undefined ? `&team_id=${teamId}` : ''

--- a/packages/fixie-common/tests/agent.test.ts
+++ b/packages/fixie-common/tests/agent.test.ts
@@ -71,6 +71,36 @@ describe('FixieAgentBase Agent tests', () => {
     expect(agents[0].agentUrl()).toBe('https://console.fixie.ai/agents/fake-agent-id-1');
   });
 
+  it('ListAgents pagination works', async () => {
+    const client = new FixieClientBase({ url: 'https://fake.api.fixie.ai' });
+    const mock = mockFetch({
+      agents: [
+        {
+          agentId: 'fake-agent-id-1',
+          handle: 'fake-agent-handle-1',
+        },
+        {
+          agentId: 'fake-agent-id-2',
+          handle: 'fake-agent-handle-2',
+        },
+        {
+          agentId: 'fake-agent-id-3',
+          handle: 'fake-agent-handle-3',
+        },
+        {
+          agentId: 'fake-agent-id-4',
+          handle: 'fake-agent-handle-4',
+        },
+      ],
+    });
+    const agents = await FixieAgentBase.ListAgents({ client, offset: 0, limit: 4 });
+    expect(mock.mock.calls[0][0].toString()).toStrictEqual('https://fake.api.fixie.ai/api/v1/agents?offset=0&limit=4');
+    expect(agents.length).toBe(4);
+    expect(agents[0].id).toBe('fake-agent-id-1');
+    expect(agents[0].handle).toBe('fake-agent-handle-1');
+    expect(agents[0].agentUrl()).toBe('https://console.fixie.ai/agents/fake-agent-id-1');
+  });
+
   it('CreateAgent works', async () => {
     const client = new FixieClientBase({ url: 'https://fake.api.fixie.ai' });
     const mock = mockFetch({

--- a/packages/fixie-web/CHANGELOG.md
+++ b/packages/fixie-web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # fixie-web
 
+## 1.0.12
+
+### Patch Changes
+
+- Fix issue with agent listing.
+- Updated dependencies
+  - @fixieai/fixie-common@1.0.14
+
 ## 1.0.11
 
 ### Patch Changes

--- a/packages/fixie-web/package.json
+++ b/packages/fixie-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fixie-web",
   "description": "Browser-based SDK for the Fixie platform.",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "dependencies": {
-    "@fixieai/fixie-common": "^1.0.13",
+    "@fixieai/fixie-common": "^1.0.14",
     "base64-arraybuffer": "^1.0.2",
     "livekit-client": "^1.15.2",
     "type-fest": "^4.3.1"

--- a/packages/fixie/CHANGELOG.md
+++ b/packages/fixie/CHANGELOG.md
@@ -1,5 +1,13 @@
 # fixie
 
+## 7.0.14
+
+### Patch Changes
+
+- Fix issue with agent listing.
+- Updated dependencies
+  - @fixieai/fixie-common@1.0.14
+
 ## 7.0.13
 
 ### Patch Changes

--- a/packages/fixie/package.json
+++ b/packages/fixie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixie",
-  "version": "7.0.13",
+  "version": "7.0.14",
   "license": "MIT",
   "repository": "fixie-ai/fixie-sdk",
   "bugs": "https://github.com/fixie-ai/fixie-sdk/issues",
@@ -22,7 +22,7 @@
   "bin": "dist/src/cli.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@fixieai/fixie-common": "^1.0.12",
+    "@fixieai/fixie-common": "^1.0.14",
     "axios": "^1.6.3",
     "commander": "^11.0.0",
     "execa": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -766,7 +766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fixieai/fixie-common@^1.0.12, @fixieai/fixie-common@^1.0.13, @fixieai/fixie-common@workspace:packages/fixie-common":
+"@fixieai/fixie-common@^1.0.14, @fixieai/fixie-common@workspace:packages/fixie-common":
   version: 0.0.0-use.local
   resolution: "@fixieai/fixie-common@workspace:packages/fixie-common"
   dependencies:
@@ -4030,7 +4030,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "fixie-web@workspace:packages/fixie-web"
   dependencies:
-    "@fixieai/fixie-common": ^1.0.13
+    "@fixieai/fixie-common": ^1.0.14
     "@tsconfig/node18": ^2.0.1
     "@types/react": ^18.2.22
     "@types/react-dom": ^18.2.7
@@ -4060,7 +4060,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "fixie@workspace:packages/fixie"
   dependencies:
-    "@fixieai/fixie-common": ^1.0.12
+    "@fixieai/fixie-common": ^1.0.14
     "@tsconfig/node18": ^2.0.1
     "@types/extract-files": ^8.1.1
     "@types/jest": ^29.5.11


### PR DESCRIPTION
There's a bug in the list agents logic whereby if the number of agents requested is the same as the number returned, we send a `?limit=0` to the server which, predictably, returns an empty list, but the query doesn't complete. This fixes that.
