### PR TITLE
Add support for custom recording template

### DIFF
--- a/packages/fixie-web/CHANGELOG.md
+++ b/packages/fixie-web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # fixie-web
 
+## 1.0.13
+
+### Patch Changes
+
+- Add support for custom recording template
+
 ## 1.0.12
 
 ### Patch Changes

--- a/packages/fixie-web/package.json
+++ b/packages/fixie-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fixie-web",
   "description": "Browser-based SDK for the Fixie platform.",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/fixie-web/src/voice.ts
+++ b/packages/fixie-web/src/voice.ts
@@ -34,6 +34,7 @@ export interface VoiceSessionInit {
   ttsModel?: string;
   ttsVoice?: string;
   webrtcUrl?: string;
+  recordingTemplateUrl?: string;
 }
 
 /** Web Audio AnalyserNode for an audio stream. */
@@ -247,6 +248,7 @@ export class VoiceSession {
           conversationId: this.conversationId,
           model: this.params?.model,
         },
+        recording: this.params?.recordingTemplateUrl ? { templateUrl: this.params.recordingTemplateUrl } : undefined,
       },
     };
     this.socket?.send(JSON.stringify(obj));


### PR DESCRIPTION
This allows the client to specify a custom recording template (the service already supports this).